### PR TITLE
fix ethnicity population

### DIFF
--- a/analysis/study_definition_ethnicity.py
+++ b/analysis/study_definition_ethnicity.py
@@ -15,10 +15,7 @@ study = StudyDefinition(
         "rate": "uniform",
     },
     index_date=end_date,
-    population=patients.registered_with_one_practice_between(
-        "index_date", "index_date"
-    ),
-
+    population=patients.all(),
     # ETHNICITY IN 6 CATEGORIES
     eth=patients.with_these_clinical_events(
         ethnicity_codes,


### PR DESCRIPTION
Ethnicity was calculated by taking any patients registered at the end of the study period.  This excluded any patients that left a TPP practice during the study.  This updates the ethnicity study population to include all patients.