### PR TITLE
Fix join ethnicity

### DIFF
--- a/analysis/join_ethnicity.py
+++ b/analysis/join_ethnicity.py
@@ -13,4 +13,4 @@ for file in os.listdir('output'):
             df = pd.read_csv(file_path)
             merged_df = df.merge(ethnicity_df, how='left', on='patient_id')
             
-            merged_df.to_csv(file_path)
+            merged_df.to_csv(file_path, index=False)

--- a/analysis/join_ethnicity.py
+++ b/analysis/join_ethnicity.py
@@ -1,16 +1,16 @@
-import pandas as pd
 import os
 
+import pandas as pd
 
-ethnicity_df = pd.read_csv('output/input_ethnicity.csv')
+ethnicity_df = pd.read_csv("output/input_ethnicity.csv")
 
 
-for file in os.listdir('output'):
-    if file.startswith('input'):
-        #exclude ethnicity
-        if file.split('_')[1] not in ['ethnicity.csv', 'practice']:
-            file_path = os.path.join('output', file)
+for file in os.listdir("output"):
+    if file.startswith("input"):
+        # exclude ethnicity
+        if file.split("_")[1] not in ["ethnicity.csv", "practice"]:
+            file_path = os.path.join("output", file)
             df = pd.read_csv(file_path)
-            merged_df = df.merge(ethnicity_df, how='left', on='patient_id')
-            
+            merged_df = df.merge(ethnicity_df, how="left", on="patient_id")
+
             merged_df.to_csv(file_path, index=False)


### PR DESCRIPTION
e8db57f is the fix. If you run `opensafely run -f run_all` before and after checking out the branch, and compare an `output/input_*` files, then you'll see that the index has been dropped.

56024b4 is the result of running `analysis/join_ethnicity.py` through [black][1] and [iSort][2]. I have these tools installed in a "scratch" virtual environment, so I can run them quickly on study repos. If you don't like the changes introduced by this commit, then that's okay 🙂 I can revert them and force push. But do consider linting, all the same.

[1]: https://black.readthedocs.io/en/stable/
[2]: https://pycqa.github.io/isort/